### PR TITLE
Feat: 사용자 아이디 찾기 기능 (이름, 이메일 인증 후)

### DIFF
--- a/src/main/java/org/example/todotravel/domain/user/controller/EmailController.java
+++ b/src/main/java/org/example/todotravel/domain/user/controller/EmailController.java
@@ -19,19 +19,6 @@ public class EmailController {
     private final EmailServiceImpl emailService;
     private final PasswordEncoder passwordEncoder;
 
-    // 임시 비밀번호 발급
-    @PostMapping("/password")
-    public ApiResponse<?> sendPasswordMail(@RequestBody EmailRequestDto emailRequestDto) {
-        EmailMessage emailMessage = EmailMessage.builder()
-            .to(emailRequestDto.getEmail())
-            .subject("[ToDoTravel] 임시 비밀번호 발급")
-            .build();
-
-        emailService.sendMail(emailMessage, "password", passwordEncoder);
-
-        return new ApiResponse<>(true, "임시 비밀번호 발급 성공", null);
-    }
-
     // 회원가입 이메일 인증 - 요청 시 body로 인증번호 반환
     @PostMapping("/email")
     public ApiResponse<?> sendJoinMail(@RequestBody EmailRequestDto emailRequestDto) {
@@ -46,5 +33,18 @@ public class EmailController {
         emailResponseDto.setCode(code);
 
         return new ApiResponse<>(true, "이메일 인증 코드 발송 성공", emailResponseDto);
+    }
+
+    // 임시 비밀번호 발급
+    @PostMapping("/password")
+    public ApiResponse<?> sendPasswordMail(@RequestBody EmailRequestDto emailRequestDto) {
+        EmailMessage emailMessage = EmailMessage.builder()
+            .to(emailRequestDto.getEmail())
+            .subject("[ToDoTravel] 임시 비밀번호 발급")
+            .build();
+
+        emailService.sendMail(emailMessage, "password", passwordEncoder);
+
+        return new ApiResponse<>(true, "임시 비밀번호 발급 성공", null);
     }
 }

--- a/src/main/java/org/example/todotravel/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/todotravel/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.todotravel.domain.user.dto.request.LoginRequestDto;
 import org.example.todotravel.domain.user.dto.request.UserRegisterRequestDto;
+import org.example.todotravel.domain.user.dto.request.UsernameRequestDto;
 import org.example.todotravel.domain.user.dto.response.LoginResponseDto;
 import org.example.todotravel.domain.user.entity.User;
 import org.example.todotravel.domain.user.service.impl.RefreshTokenServiceImpl;
@@ -25,30 +26,35 @@ public class UserController {
     private final RefreshTokenServiceImpl refreshTokenService;
     private final JwtTokenizer jwtTokenizer;
 
+    // 회원가입
     @PostMapping("/signup")
     public ApiResponse<?> registerUser(@Valid @RequestBody UserRegisterRequestDto dto) {
         User newUser = userService.registerNewUser(dto, passwordEncoder);
         return new ApiResponse<>(true, "회원가입 성공", newUser);
     }
 
+    // 사용자 아이디 중복 검사
     @PostMapping("/check-username")
     public ApiResponse<?> checkUsername(@RequestParam String username) {
         userService.checkDuplicateUsername(username);
         return new ApiResponse<>(true, "아이디 사용 가능", username);
     }
 
+    // 사용자 이메일 중복 검사
     @PostMapping("/check-email")
     public ApiResponse<?> checkEmail(@RequestParam String email) {
         userService.checkDuplicateEmail(email);
         return new ApiResponse<>(true, "이메일 사용 가능", email);
     }
 
+    // 사용자 닉네임 중복 검사
     @PostMapping("/check-nickname")
     public ApiResponse<?> checkNickname(@RequestParam String nickname) {
         userService.checkDuplicateUsername(nickname);
         return new ApiResponse<>(true, "닉네임 사용 가능", nickname);
     }
 
+    // 로그인
     @PostMapping("/login")
     public ApiResponse<?> login(@Valid @RequestBody LoginRequestDto dto,
                                 HttpServletResponse response) {
@@ -66,6 +72,14 @@ public class UserController {
         return new ApiResponse<>(true, "로그인 성공", loginResponseDto);
     }
 
+    // 아이디 찾기
+    @PostMapping("/find-username")
+    public ApiResponse<?> findUsername(@Valid @RequestBody UsernameRequestDto dto) {
+        String username = userService.getUsername(dto);
+        return new ApiResponse<>(true, "아이디 찾기 성공", username);
+    }
+
+    // 로그아웃
     @PostMapping("/logout")
     public ApiResponse<?> logout(HttpServletRequest request, HttpServletResponse response) {
         Cookie[] cookies = request.getCookies();

--- a/src/main/java/org/example/todotravel/domain/user/dto/request/UsernameRequestDto.java
+++ b/src/main/java/org/example/todotravel/domain/user/dto/request/UsernameRequestDto.java
@@ -1,0 +1,20 @@
+package org.example.todotravel.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsernameRequestDto {
+    @Pattern(regexp = "^[\\S]+$", message = "이름에 공백을 포함할 수 없습니다.")
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    private String name;
+
+    @Pattern(regexp = "^(?:\\w+\\.?)*\\w+@(?:\\w+\\.)+\\w+$", message = "이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    private String email;
+}

--- a/src/main/java/org/example/todotravel/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/todotravel/domain/user/repository/UserRepository.java
@@ -4,7 +4,6 @@ import org.example.todotravel.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByNickname(String nickname);
+
+    Optional<User> findByNameAndEmail(String name, String email);
 }

--- a/src/main/java/org/example/todotravel/domain/user/service/UserService.java
+++ b/src/main/java/org/example/todotravel/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package org.example.todotravel.domain.user.service;
 
 import org.example.todotravel.domain.user.dto.request.UserRegisterRequestDto;
+import org.example.todotravel.domain.user.dto.request.UsernameRequestDto;
 import org.example.todotravel.domain.user.entity.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,9 +21,11 @@ public interface UserService {
 
     void checkDuplicateNickname(String nickname);
 
-    void setTempPassword(String email, String tempPassword, PasswordEncoder passwordEncoder);
-
     User checkLoginAvailable(String username, String password, PasswordEncoder passwordEncoder);
+
+    String getUsername(UsernameRequestDto dto);
+
+    void setTempPassword(String email, String tempPassword, PasswordEncoder passwordEncoder);
 
     //플랜에 사용자 초대 시 모든 사용자 목록을 return - 김민정
     List<User> getAllUsers();

--- a/src/main/java/org/example/todotravel/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/user/service/impl/UserServiceImpl.java
@@ -2,6 +2,7 @@ package org.example.todotravel.domain.user.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.example.todotravel.domain.user.dto.request.UserRegisterRequestDto;
+import org.example.todotravel.domain.user.dto.request.UsernameRequestDto;
 import org.example.todotravel.domain.user.entity.Role;
 import org.example.todotravel.domain.user.entity.User;
 import org.example.todotravel.domain.user.repository.UserRepository;
@@ -78,18 +79,6 @@ public class UserServiceImpl implements UserService {
         }
     }
 
-    // 임시 비밀번호 재설정
-    @Override
-    @Transactional
-    public void setTempPassword(String email, String tempPassword, PasswordEncoder passwordEncoder) {
-        User user = userRepository.findByEmail(email)
-            .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
-
-        user.setPassword(passwordEncoder.encode(tempPassword));
-
-        userRepository.save(user);
-    }
-
     // 로그인 가능한지 확인
     @Override
     @Transactional(readOnly = true)
@@ -102,6 +91,28 @@ public class UserServiceImpl implements UserService {
         }
 
         return user;
+    }
+
+    // 임시 비밀번호 재설정
+    @Override
+    @Transactional
+    public void setTempPassword(String email, String tempPassword, PasswordEncoder passwordEncoder) {
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
+
+        user.setPassword(passwordEncoder.encode(tempPassword));
+
+        userRepository.save(user);
+    }
+
+    // 이름, 이메일로 아이디 찾기
+    @Override
+    @Transactional
+    public String getUsername(UsernameRequestDto dto) {
+        User user = userRepository.findByNameAndEmail(dto.getName(), dto.getEmail())
+            .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
+
+        return user.getUsername();
     }
 
     //플랜에 사용자 초대 시 모든 사용자 목록을 return - 김민정

--- a/src/main/java/org/example/todotravel/global/jwt/util/JwtTokenizer.java
+++ b/src/main/java/org/example/todotravel/global/jwt/util/JwtTokenizer.java
@@ -31,7 +31,7 @@ public class JwtTokenizer {
     private final byte[] refreshSecret;
 
     public static Long ACCESS_TOKEN_EXPIRATION_COUNT = 30 * 60 * 1000L;     // 30분
-    public static Long REFRESH_TOKEN_EXPIRATION_COUNT = 7 * 24 * 60 * 60 * 1000L;   // 7일
+    public static Long REFRESH_TOKEN_EXPIRATION_COUNT = 14 * 24 * 60 * 60 * 1000L;   // 14일
 
     public JwtTokenizer(@Value("${jwt.secretKey}") String accessSecret,
                         @Value("${jwt.refreshKey}") String refreshSecret,


### PR DESCRIPTION
## 변경 사항
사용자 아이디 찾기 기능 (이름, 이메일 인증 후)

## To Reviewers
1. 이름, 이메일 인증 후 사용자 아이디 찾기 기능을 추가했습니다.
2. RefreshToken의 만료 시간을 14일로 설정했습니다.
- 자동 로그인 구현을 해볼까 하다가 JWT의 RefreshToken 자체가 자동 로그인의 역할을 하기 때문에 여행 플랫폼의 특성상 7일 보단 14일 정도로 하는 것이 좋아보여 14일로 변경하였습니다.


## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).