### PR TITLE
Feat/Refactor: 마이페이지 관련 수정 및 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/org/example/todotravel/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/org/example/todotravel/domain/chat/repository/ChatMessageRepository.java
@@ -1,11 +1,22 @@
 package org.example.todotravel.domain.chat.repository;
 
 import org.example.todotravel.domain.chat.entity.ChatMessage;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import org.springframework.data.mongodb.repository.Update;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @Repository
 public interface ChatMessageRepository extends ReactiveMongoRepository<ChatMessage, String> {
     Flux<ChatMessage> findAllByRoomId(Long roomId);
+
+    @Query("{ 'userId':  ?0 }")
+    @Update("{ '$set': { 'nickname': ?1 } }")
+    Mono<Long> updateNicknameByUserId(Long userId, String newNickname);
+
+    Mono<ChatMessage> findFirstByUserId(Long userId);
+
+    Mono<Void> deleteAllByRoomId(Long roomId);
 }

--- a/src/main/java/org/example/todotravel/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/example/todotravel/domain/chat/repository/ChatRoomRepository.java
@@ -1,12 +1,15 @@
 package org.example.todotravel.domain.chat.repository;
 
 import org.example.todotravel.domain.chat.entity.ChatRoom;
+import org.example.todotravel.domain.plan.entity.Plan;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByPlanPlanId(Long planId);
+    List<ChatRoom> findByPlanIn(List<Plan> plans);
 }

--- a/src/main/java/org/example/todotravel/domain/chat/repository/ChatRoomUserRepository.java
+++ b/src/main/java/org/example/todotravel/domain/chat/repository/ChatRoomUserRepository.java
@@ -34,4 +34,6 @@ public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long
     List<ChatRoomUser> findByChatRoomRoomId(Long roomId);
 
     Optional<ChatRoomUser> findByUserAndChatRoomRoomId(User user, Long roomId);
+
+    boolean existsByChatRoomAndUser(ChatRoom chatRoom, User user);
 }

--- a/src/main/java/org/example/todotravel/domain/chat/repository/ChatRoomUserRepository.java
+++ b/src/main/java/org/example/todotravel/domain/chat/repository/ChatRoomUserRepository.java
@@ -4,6 +4,7 @@ import org.example.todotravel.domain.chat.entity.ChatRoom;
 import org.example.todotravel.domain.chat.entity.ChatRoomUser;
 import org.example.todotravel.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -36,4 +37,10 @@ public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long
     Optional<ChatRoomUser> findByUserAndChatRoomRoomId(User user, Long roomId);
 
     boolean existsByChatRoomAndUser(ChatRoom chatRoom, User user);
+
+    void deleteByChatRoom(ChatRoom chatRoom);
+
+    @Modifying
+    @Query("DELETE FROM ChatRoomUser cru WHERE cru.chatRoom.roomId = :roomId AND cru.user.userId = :userId")
+    void deleteByChatRoomIdAndUserId(@Param("roomId") Long roomId, @Param("userId") Long userId);
 }

--- a/src/main/java/org/example/todotravel/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/org/example/todotravel/domain/chat/service/ChatMessageService.java
@@ -9,4 +9,8 @@ import reactor.core.publisher.Mono;
 public interface ChatMessageService {
     Flux<ChatMessageResponseDto> findChatMessages(Long roomId);
     Mono<ChatMessage> saveChatMessage(ChatMessageRequestDto dto);
+    Mono<Void> deleteAllMessageForChatRoom(Long roomId);
+    Mono<Void> updateNicknameForUser(Long userId, String newNickname);
+    Mono<Void> restoreMessagesForChatRoom(Long roomId);
+    Mono<Void> restoreNicknameForUser(Long userId, String oldNickname);
 }

--- a/src/main/java/org/example/todotravel/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/org/example/todotravel/domain/chat/service/ChatRoomService.java
@@ -8,12 +8,15 @@ import org.example.todotravel.domain.chat.dto.response.ChatRoomResponseDto;
 import org.example.todotravel.domain.chat.entity.ChatRoom;
 import org.example.todotravel.domain.plan.entity.Plan;
 
+import java.util.List;
+
 public interface ChatRoomService {
     ChatRoomResponseDto createChatRoom(Plan plan);
     ChatRoomResponseDto createOneToOneChatRoom(OneToOneChatRoomRequestDto dto);
     ChatRoomNameResponseDto updateChatRoomName(ChatRoomNameRequestDto dto);
     void addUserToChatRoom(Long roomId, Long userId);
     ChatRoom getChatRoomByPlanId(Long planId);
+    List<ChatRoom> getAllChatRoomByPlan(List<Plan> plans);
     Plan getPlanByRoomId(Long roomId);
     void removeUserFromChatRoom(Long roomId, Long userId);
     void deleteChatRoom(Long roomId);

--- a/src/main/java/org/example/todotravel/domain/chat/service/ChatRoomUserService.java
+++ b/src/main/java/org/example/todotravel/domain/chat/service/ChatRoomUserService.java
@@ -19,4 +19,8 @@ public interface ChatRoomUserService {
     List<ChatRoomUserResponseDto> getUsersByRoomId(Long roomId);
 
     boolean checkUserInChatRoom(ChatRoom chatRoom, User user);
+
+    void removeAllUserFromChatRoom(ChatRoom chatRoom);
+
+    void removeUserFromChatRoom(ChatRoom chatRoom, User user);
 }

--- a/src/main/java/org/example/todotravel/domain/chat/service/ChatRoomUserService.java
+++ b/src/main/java/org/example/todotravel/domain/chat/service/ChatRoomUserService.java
@@ -3,6 +3,7 @@ package org.example.todotravel.domain.chat.service;
 import org.example.todotravel.domain.chat.dto.request.FirstUserCheckRequestDto;
 import org.example.todotravel.domain.chat.dto.response.ChatRoomListResponseDto;
 import org.example.todotravel.domain.chat.dto.response.ChatRoomUserResponseDto;
+import org.example.todotravel.domain.chat.entity.ChatRoom;
 import org.example.todotravel.domain.chat.entity.ChatRoomUser;
 import org.example.todotravel.domain.user.entity.User;
 
@@ -16,4 +17,6 @@ public interface ChatRoomUserService {
     ChatRoomUser getUserByUserId(User user);
 
     List<ChatRoomUserResponseDto> getUsersByRoomId(Long roomId);
+
+    boolean checkUserInChatRoom(ChatRoom chatRoom, User user);
 }

--- a/src/main/java/org/example/todotravel/domain/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/chat/service/impl/ChatMessageServiceImpl.java
@@ -1,7 +1,9 @@
 package org.example.todotravel.domain.chat.service.impl;
 
 import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.todotravel.domain.chat.dto.request.ChatMessageRequestDto;
 import org.example.todotravel.domain.chat.dto.response.ChatMessageResponseDto;
 import org.example.todotravel.domain.chat.entity.ChatMessage;
@@ -11,27 +13,32 @@ import org.example.todotravel.domain.chat.repository.ChatRoomUserRepository;
 import org.example.todotravel.domain.chat.service.ChatMessageService;
 import org.example.todotravel.domain.user.entity.User;
 import org.example.todotravel.domain.user.repository.UserRepository;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatMessageServiceImpl implements ChatMessageService {
 
-private final ChatMessageRepository chatMessageRepository;
-private final ChatRoomUserRepository chatRoomUserRepository;
-private final UserRepository userRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
+    private final UserRepository userRepository;
+    private final ReactiveMongoTemplate reactiveMongoTemplate;
+    private final TransactionalOperator transactionalOperator;
 
-//     이전 채팅 내용 조회
+    // 이전 채팅 내용 조회
     @Transactional
     public Flux<ChatMessageResponseDto> findChatMessages(Long roomId) {
         Flux<ChatMessage> chatMessages = chatMessageRepository.findAllByRoomId(roomId);
         return chatMessages.map(ChatMessageResponseDto::of);
     }
 
-// 메시지 저장
+    // 메시지 저장
     @Transactional
     public Mono<ChatMessage> saveChatMessage(ChatMessageRequestDto dto) {
         Long userId = dto.getUserId();
@@ -51,6 +58,95 @@ private final UserRepository userRepository;
                     dto.getContent()
                 );
                 return chatMessageRepository.save(chatMessage);
+            });
+    }
+
+    // 회원 탈퇴 시 사용자가 생성한 채팅방의 모든 메시지 삭제
+    @Override
+    public Mono<Void> deleteAllMessageForChatRoom(Long roomId) {
+        return transactionalOperator.execute(tx ->
+                chatMessageRepository.findAllByRoomId(roomId)
+                    .collectList()
+                    .flatMap(messages -> {
+                        if (!messages.isEmpty()) {
+                            // 메시지가 있으면 삭제된 메시지 컬렉션에 저장 후 원본 삭제
+                            return reactiveMongoTemplate.insert(messages, "deleted_messages")
+                                .then(chatMessageRepository.deleteAllByRoomId(roomId));
+                        }
+                        log.info("No messages found for room ID: {}", roomId);
+                        return Mono.empty();
+                    })
+            ).then()
+            .doOnSuccess(v -> log.info("Deleted all messages for room ID: {}", roomId))
+            .onErrorResume(e -> {
+                log.error("Error deleting messages for room ID: {}", roomId, e);
+                return Mono.empty(); // 오류 발생 시에도 Mono.empty()를 반환하여 계속 진행
+            });
+    }
+
+    // 회원 탈퇴 과정에서 오류 발생 시 삭제한 메시지를 복구하는 대한 보상 트랜잭션
+    @Override
+    public Mono<Void> restoreMessagesForChatRoom(Long roomId) {
+        return transactionalOperator.execute(tx ->
+                reactiveMongoTemplate.find(
+                        org.springframework.data.mongodb.core.query.Query.query(
+                            org.springframework.data.mongodb.core.query.Criteria.where("roomId").is(roomId)
+                        ),
+                        ChatMessage.class,
+                        "deleted_messages"
+                    )
+                    .collectList()
+                    .flatMap(deletedMessages -> {
+                        if (!deletedMessages.isEmpty()) {
+                            // 삭제된 메시지가 있으면 원본 컬렉션에 복구 후 삭제된 메시지 컬렉션에서 제거
+                            return chatMessageRepository.saveAll(deletedMessages)
+                                .then(reactiveMongoTemplate.remove(
+                                    org.springframework.data.mongodb.core.query.Query.query(
+                                        org.springframework.data.mongodb.core.query.Criteria.where("roomId").is(roomId)
+                                    ),
+                                    "deleted_messages"
+                                ));
+                        }
+                        return Mono.empty();
+                    })
+            ).then()
+            .doOnSuccess(v -> log.info("Restored messages for room ID: {}", roomId))
+            .onErrorResume(e -> {
+                log.error("Error restoring messages for room ID: {}", roomId, e);
+                return Mono.error(e);
+            });
+    }
+
+    // 회원 탈퇴 시 채팅 내역에서 사용자 닉네임을 업데이트
+    @Override
+    public Mono<Void> updateNicknameForUser(Long userId, String newNickname) {
+        return transactionalOperator.execute(tx ->
+                chatMessageRepository.updateNicknameByUserId(userId, newNickname)
+                    .flatMap(modifiedCount -> {
+                        if (modifiedCount > 0) {
+                            log.info("Updated nickname for user ID: {} to {}", userId, newNickname);
+                        } else {
+                            log.info("No messages found to update nickname for user ID: {}", userId);
+                        }
+                        return Mono.empty();
+                    })
+            ).then()
+            .doOnSuccess(v -> log.info("Completed nickname update process for user ID: {}", userId))
+            .onErrorResume(e -> {
+                log.error("Error during nickname update process for user ID: {}", userId, e);
+                return Mono.empty(); // 오류 발생 시에도 Mono.empty()를 반환하여 계속 진행
+            });
+    }
+
+    // 회원 탈퇴 과정에서 오류 발생 시 이전 닉네임으로 복구하는 보상 트랜잭션 수행
+    @Override
+    public Mono<Void> restoreNicknameForUser(Long userId, String oldNickname) {
+        return chatMessageRepository.updateNicknameByUserId(userId, oldNickname)
+            .then()
+            .doOnSuccess(v -> log.info("Restored old nickname for user ID: {}", userId))
+            .onErrorResume(e -> {
+                log.error("Error restoring old nickname for user ID: {}", userId, e);
+                return Mono.empty();
             });
     }
 }

--- a/src/main/java/org/example/todotravel/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -86,6 +86,12 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             .orElseThrow(() -> new EntityNotFoundException("채팅방을 찾을 수 없습니다."));
         User user = userService.getUserById(userId);
 
+        // 사용자가 이미 채팅방에 존재하는지 확인
+        boolean userExists = chatRoomUserService.checkUserInChatRoom(chatRoom, user);
+        if (userExists) {
+            throw new RuntimeException("이미 채팅방에 존재하는 사용자입니다.");
+        }
+
         chatRoom.addUser(user);
         chatRoomRepository.save(chatRoom);
     }

--- a/src/main/java/org/example/todotravel/domain/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/chat/service/impl/ChatRoomServiceImpl.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -102,6 +104,13 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     public ChatRoom getChatRoomByPlanId(Long planId) {
         return chatRoomRepository.findByPlanPlanId(planId)
             .orElseThrow(() -> new EntityNotFoundException("채팅방을 찾을 수 없습니다."));
+    }
+
+    // Plan으로 채팅방 찾기
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChatRoom> getAllChatRoomByPlan(List<Plan> plans) {
+        return chatRoomRepository.findByPlanIn(plans);
     }
 
     // roomId로 plan 찾기

--- a/src/main/java/org/example/todotravel/domain/chat/service/impl/ChatRoomUserServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/chat/service/impl/ChatRoomUserServiceImpl.java
@@ -1,26 +1,32 @@
 package org.example.todotravel.domain.chat.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.todotravel.domain.chat.dto.request.FirstUserCheckRequestDto;
 import org.example.todotravel.domain.chat.dto.response.ChatRoomListResponseDto;
 import org.example.todotravel.domain.chat.dto.response.ChatRoomUserResponseDto;
 import org.example.todotravel.domain.chat.entity.ChatRoom;
 import org.example.todotravel.domain.chat.entity.ChatRoomUser;
 import org.example.todotravel.domain.chat.repository.ChatRoomUserRepository;
+import org.example.todotravel.domain.chat.service.ChatMessageService;
 import org.example.todotravel.domain.chat.service.ChatRoomUserService;
 import org.example.todotravel.domain.user.entity.User;
 import org.example.todotravel.global.exception.UserNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatRoomUserServiceImpl implements ChatRoomUserService {
     private final ChatRoomUserRepository chatRoomUserRepository;
+    private final ChatMessageService chatMessageService;
 
     // 특정 채팅방의 첫 번째 유저인지 판별
     @Override
@@ -76,5 +82,19 @@ public class ChatRoomUserServiceImpl implements ChatRoomUserService {
     @Transactional(readOnly = true)
     public boolean checkUserInChatRoom(ChatRoom chatRoom, User user) {
         return chatRoomUserRepository.existsByChatRoomAndUser(chatRoom, user);
+    }
+
+    // 회원 탈퇴 시 특정 채팅방의 사용자 모두 제거
+    @Override
+    @Transactional
+    public void removeAllUserFromChatRoom(ChatRoom chatRoom) {
+        chatRoomUserRepository.deleteByChatRoom(chatRoom);
+    }
+
+    // 회원 탈퇴 시 채팅방에서 사용자 제거
+    @Override
+    @Transactional
+    public void removeUserFromChatRoom(ChatRoom chatRoom, User user) {
+        chatRoomUserRepository.deleteByChatRoomIdAndUserId(chatRoom.getRoomId(), user.getUserId());
     }
 }

--- a/src/main/java/org/example/todotravel/domain/chat/service/impl/ChatRoomUserServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/chat/service/impl/ChatRoomUserServiceImpl.java
@@ -70,4 +70,11 @@ public class ChatRoomUserServiceImpl implements ChatRoomUserService {
                 .build())
             .collect(Collectors.toList());
     }
+
+    // 채팅방에 존재하는 사용자인지 확인
+    @Override
+    @Transactional(readOnly = true)
+    public boolean checkUserInChatRoom(ChatRoom chatRoom, User user) {
+        return chatRoomUserRepository.existsByChatRoomAndUser(chatRoom, user);
+    }
 }

--- a/src/main/java/org/example/todotravel/domain/plan/dto/response/CommentSummaryResponseDto.java
+++ b/src/main/java/org/example/todotravel/domain/plan/dto/response/CommentSummaryResponseDto.java
@@ -9,5 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CommentSummaryResponseDto {
     private Long planId;
+    private String title;
+    private String location;
     private String content;
 }

--- a/src/main/java/org/example/todotravel/domain/plan/repository/BookmarkRepository.java
+++ b/src/main/java/org/example/todotravel/domain/plan/repository/BookmarkRepository.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     void deleteByPlanAndBookmarkUser(Plan plan, User user);
-    void deleteAllByPlan(Plan plan);
     void deleteAllByBookmarkUser(User user);
     Long countByPlan(Plan plan);
     Long countByPlanPlanId(Long planId);

--- a/src/main/java/org/example/todotravel/domain/plan/repository/BookmarkRepository.java
+++ b/src/main/java/org/example/todotravel/domain/plan/repository/BookmarkRepository.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     void deleteByPlanAndBookmarkUser(Plan plan, User user);
+    void deleteAllByPlan(Plan plan);
+    void deleteAllByBookmarkUser(User user);
     Long countByPlan(Plan plan);
     Long countByPlanPlanId(Long planId);
     Optional<Bookmark> findByBookmarkUserAndPlan(User user, Plan plan);

--- a/src/main/java/org/example/todotravel/domain/plan/repository/CommentRepository.java
+++ b/src/main/java/org/example/todotravel/domain/plan/repository/CommentRepository.java
@@ -3,7 +3,9 @@ package org.example.todotravel.domain.plan.repository;
 import org.example.todotravel.domain.plan.dto.response.CommentSummaryResponseDto;
 import org.example.todotravel.domain.plan.entity.Comment;
 import org.example.todotravel.domain.plan.entity.Plan;
+import org.example.todotravel.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -13,6 +15,12 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByPlan(Plan plan);
+
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.commentUser = :user")
+    void deleteAllByCommentUserWithQuery(@Param("user") User user);
+
+    void deleteAllByPlan(Plan plan);
 
     @Query("""
         SELECT NEW org.example.todotravel.domain.plan.dto.response.CommentSummaryResponseDto(

--- a/src/main/java/org/example/todotravel/domain/plan/repository/CommentRepository.java
+++ b/src/main/java/org/example/todotravel/domain/plan/repository/CommentRepository.java
@@ -17,6 +17,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("""
         SELECT NEW org.example.todotravel.domain.plan.dto.response.CommentSummaryResponseDto(
             c.plan.planId,
+            c.plan.title,
+            c.plan.location,
             (SELECT c2.content FROM Comment c2
              WHERE c2.plan = c.plan
              AND c2.commentId = (SELECT MAX(c3.commentId) FROM Comment c3 WHERE c3.plan = c.plan))
@@ -31,6 +33,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("""
         SELECT NEW org.example.todotravel.domain.plan.dto.response.CommentSummaryResponseDto(
             c.plan.planId,
+            c.plan.title,
+            c.plan.location,
             c.content
         )
         FROM Comment c

--- a/src/main/java/org/example/todotravel/domain/plan/repository/CommentRepository.java
+++ b/src/main/java/org/example/todotravel/domain/plan/repository/CommentRepository.java
@@ -20,8 +20,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("DELETE FROM Comment c WHERE c.commentUser = :user")
     void deleteAllByCommentUserWithQuery(@Param("user") User user);
 
-    void deleteAllByPlan(Plan plan);
-
     @Query("""
         SELECT NEW org.example.todotravel.domain.plan.dto.response.CommentSummaryResponseDto(
             c.plan.planId,

--- a/src/main/java/org/example/todotravel/domain/plan/repository/LikeRepository.java
+++ b/src/main/java/org/example/todotravel/domain/plan/repository/LikeRepository.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
     void deleteByPlanAndLikeUser(Plan plan, User user);
-    void deleteAllByPlan(Plan plan);
     void deleteAllByLikeUser(User user);
     Long countByPlan(Plan plan);
     Long countByPlanPlanId(Long planId);

--- a/src/main/java/org/example/todotravel/domain/plan/repository/LikeRepository.java
+++ b/src/main/java/org/example/todotravel/domain/plan/repository/LikeRepository.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
     void deleteByPlanAndLikeUser(Plan plan, User user);
+    void deleteAllByPlan(Plan plan);
+    void deleteAllByLikeUser(User user);
     Long countByPlan(Plan plan);
     Long countByPlanPlanId(Long planId);
 

--- a/src/main/java/org/example/todotravel/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/org/example/todotravel/domain/plan/repository/PlanRepository.java
@@ -1,6 +1,7 @@
 package org.example.todotravel.domain.plan.repository;
 
 import org.example.todotravel.domain.plan.entity.Plan;
+import org.example.todotravel.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,7 +11,9 @@ import java.util.Optional;
 @Repository
 public interface PlanRepository extends JpaRepository<Plan, Long> {
     void deleteByPlanId(Long planId);
+    void deleteAllByPlanUser(User user);
     Optional<Plan> findByPlanId(Long planId);
     List<Plan> findAllByIsPublicTrue();
     List<Plan> findAllByIsPublicTrueAndTitleContains(String keyword);
+    List<Plan> findByPlanUser(User user);
 }

--- a/src/main/java/org/example/todotravel/domain/plan/repository/PlanUserRepository.java
+++ b/src/main/java/org/example/todotravel/domain/plan/repository/PlanUserRepository.java
@@ -4,6 +4,7 @@ import org.example.todotravel.domain.plan.entity.Plan;
 import org.example.todotravel.domain.plan.entity.PlanUser;
 import org.example.todotravel.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -15,6 +16,12 @@ public interface PlanUserRepository extends JpaRepository<PlanUser, Long> {
     List<PlanUser> findAllByPlan(Plan plan);
 
     void deletePlanUserByPlanAndUser(Plan plan, User user);
+
+    void deleteAllByPlan(Plan plan);
+
+    @Modifying
+    @Query("DELETE FROM PlanUser pu WHERE pu.plan.planId = :planId AND pu.user.userId = :userId")
+    void deleteByPlanIdAndUserId(@Param("planId") Long planId, @Param("userId") Long userId);
 
     @Query("""
         SELECT pu.plan FROM PlanUser pu 

--- a/src/main/java/org/example/todotravel/domain/plan/repository/ScheduleRepository.java
+++ b/src/main/java/org/example/todotravel/domain/plan/repository/ScheduleRepository.java
@@ -11,4 +11,5 @@ import java.util.List;
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     //플랜 상세 조회 - 김민정
     List<Schedule> findAllByPlan(Plan plan);
+    void deleteAllByPlan(Plan plan);
 }

--- a/src/main/java/org/example/todotravel/domain/plan/service/BookmarkService.java
+++ b/src/main/java/org/example/todotravel/domain/plan/service/BookmarkService.java
@@ -10,6 +10,8 @@ import java.util.List;
 public interface BookmarkService {
     Bookmark createBookmark(Plan plan, User user);
     void removeBookmark(Plan plan, User user);
+    void removeAllBookmarksByPlan(Plan plan);
+    void removeAllBookmarkByUser(User user);
     Long countBookmark(Plan plan);
     Long countBookmarkByPlanId(Long planId);
     Boolean isPlanBookmarkedByUser(User user, Plan plan);

--- a/src/main/java/org/example/todotravel/domain/plan/service/CommentService.java
+++ b/src/main/java/org/example/todotravel/domain/plan/service/CommentService.java
@@ -13,6 +13,8 @@ public interface CommentService {
     Comment getComment(Long commentId);
     Comment updateComment(Long commentId, CommentRequestDto commentRequestDto);
     void removeComment(Long commentId);
+    void removeAllCommentByPlan(Plan plan);
+    void removeAllCommentByUser(User user);
     List<Comment> getCommentsByPlan(Plan plan);
     List<CommentSummaryResponseDto> getAllCommentedPlansByUser(User user);
     List<CommentSummaryResponseDto> getRecentCommentedPlansByUser(User user);

--- a/src/main/java/org/example/todotravel/domain/plan/service/LikeService.java
+++ b/src/main/java/org/example/todotravel/domain/plan/service/LikeService.java
@@ -11,6 +11,8 @@ import java.util.List;
 public interface LikeService {
     Like createLike(Plan plan, User user);
     void removeLike(Plan plan, User user);
+    void removeAllLikeByPlan(Plan plan);
+    void removeAllLikeByUser(User user);
     Long countLike(Plan plan);
     Long countLikeByPlanId(Long planId);
     Boolean isPlanLikedByUser(User user, Plan plan);

--- a/src/main/java/org/example/todotravel/domain/plan/service/PlanService.java
+++ b/src/main/java/org/example/todotravel/domain/plan/service/PlanService.java
@@ -11,6 +11,7 @@ import java.util.List;
 public interface PlanService {
     Plan createPlan(PlanRequestDto planRequestDto, User user);
     void deletePlan(Long planId);
+    void removeAllPlanByUser(User user);
     Plan getPlan(Long planId);
     Plan updatePlan(Long planId, PlanRequestDto dto);
     List<PlanListResponseDto> getPublicPlans();
@@ -25,4 +26,6 @@ public interface PlanService {
     List<PlanListResponseDto> getRecentLikedPlans(User user);
     List<PlanListResponseDto> getAllLikedPlans(User user);
     PlanListResponseDto convertToPlanListResponseDto(Plan plan);
+
+    List<Plan> getAllPlanByPlanUser(User user);
 }

--- a/src/main/java/org/example/todotravel/domain/plan/service/PlanUserService.java
+++ b/src/main/java/org/example/todotravel/domain/plan/service/PlanUserService.java
@@ -1,6 +1,7 @@
 package org.example.todotravel.domain.plan.service;
 
 import org.example.todotravel.domain.plan.dto.response.PlanListResponseDto;
+import org.example.todotravel.domain.plan.entity.Plan;
 import org.example.todotravel.domain.plan.entity.PlanUser;
 import org.example.todotravel.domain.user.dto.response.MyProfileResponseDto;
 import org.example.todotravel.domain.user.dto.response.UserProfileResponseDto;
@@ -14,8 +15,11 @@ public interface PlanUserService {
     PlanUser accepted(Long planParticipantId);
     List<PlanUser> getAllPlanUser(Long planId);
     void removePlanUser(Long planId, Long userId);
+    void removePlanUserFromOwnPlan(Plan plan);
+    void removePlanUserFromPlan(Plan plan, User user);
 
     UserProfileResponseDto getUserProfile(String subject, User user, boolean isFollowing);
-    List<PlanListResponseDto> getAllPlansByUser(Long userId);
+    List<Plan> getAllPlansByUser(User user);
+    List<PlanListResponseDto> getAllPlansByUserAndStatus(Long userId);
     List<PlanListResponseDto> getRecentPlansByUser(Long userId);
 }

--- a/src/main/java/org/example/todotravel/domain/plan/service/ScheduleService.java
+++ b/src/main/java/org/example/todotravel/domain/plan/service/ScheduleService.java
@@ -2,6 +2,7 @@ package org.example.todotravel.domain.plan.service;
 
 import org.example.todotravel.domain.plan.dto.request.ScheduleCreateRequestDto;
 import org.example.todotravel.domain.plan.dto.response.ScheduleResponseDto;
+import org.example.todotravel.domain.plan.entity.Plan;
 import org.example.todotravel.domain.plan.entity.Schedule;
 import org.springframework.stereotype.Service;
 
@@ -24,4 +25,6 @@ public interface ScheduleService {
 
     //플랜 상세 조회 - 김민정
     List<ScheduleResponseDto> getSchedulesByPlan(Long planId);
+
+    void deleteAllSchedulesByPlan(Plan plan);
 }

--- a/src/main/java/org/example/todotravel/domain/plan/service/implement/BookmarkServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/plan/service/implement/BookmarkServiceImpl.java
@@ -42,6 +42,20 @@ public class BookmarkServiceImpl implements BookmarkService {
         bookmarkRepository.deleteByPlanAndBookmarkUser(plan, user);
     }
 
+    // 회원 탈퇴 시 사용자가 생성한 플랜의 북마크 삭제
+    @Override
+    @Transactional
+    public void removeAllBookmarksByPlan(Plan plan) {
+        bookmarkRepository.deleteAllByPlan(plan);
+    }
+
+    // 회원 탈퇴 시 북마크 전체 삭제
+    @Override
+    @Transactional
+    public void removeAllBookmarkByUser(User user) {
+        bookmarkRepository.deleteAllByBookmarkUser(user);
+    }
+
     @Override
     @Transactional(readOnly = true)
     public Long countBookmark(Plan plan) {

--- a/src/main/java/org/example/todotravel/domain/plan/service/implement/CommentServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/plan/service/implement/CommentServiceImpl.java
@@ -10,6 +10,8 @@ import org.example.todotravel.domain.plan.entity.Plan;
 import org.example.todotravel.domain.plan.repository.CommentRepository;
 import org.example.todotravel.domain.plan.service.CommentService;
 import org.example.todotravel.domain.user.entity.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class CommentServiceImpl implements CommentService {
+    private static final Logger log = LoggerFactory.getLogger(CommentServiceImpl.class);
     private final CommentRepository commentRepository;
     private final AlarmService alarmService; //알림 자동 생성
 
@@ -61,6 +64,21 @@ public class CommentServiceImpl implements CommentService {
     public void removeComment(Long commentId) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
         commentRepository.delete(comment);
+    }
+
+    // 회원 탈퇴 시 사용자가 생성한 플랜의 댓글 삭제
+    @Override
+    @Transactional
+    public void removeAllCommentByPlan(Plan plan) {
+        commentRepository.deleteAllByPlan(plan);
+    }
+
+    // 회원 탈퇴 시 댓글 전체 삭제
+    @Override
+    @Transactional
+    public void removeAllCommentByUser(User user) {
+        commentRepository.deleteAllByCommentUserWithQuery(user);
+        log.info("댓글 삭제를 거칩니다");
     }
 
     @Override

--- a/src/main/java/org/example/todotravel/domain/plan/service/implement/LikeServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/plan/service/implement/LikeServiceImpl.java
@@ -42,6 +42,20 @@ public class LikeServiceImpl implements LikeService {
         likeRepository.deleteByPlanAndLikeUser(plan, user);
     }
 
+    // 회원 탈퇴 시 사용자가 생성한 플랜의 좋아요 삭제
+    @Override
+    @Transactional
+    public void removeAllLikeByPlan(Plan plan) {
+        likeRepository.deleteAllByPlan(plan);
+    }
+
+    // 회원 탈퇴 시 좋아요 전체 삭제
+    @Override
+    @Transactional
+    public void removeAllLikeByUser(User user) {
+        likeRepository.deleteAllByLikeUser(user);
+    }
+
     @Override
     @Transactional(readOnly = true)
     public Long countLike(Plan plan) {

--- a/src/main/java/org/example/todotravel/domain/plan/service/implement/PlanServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/plan/service/implement/PlanServiceImpl.java
@@ -86,6 +86,13 @@ public class PlanServiceImpl implements PlanService {
         planRepository.deleteByPlanId(planId);
     }
 
+    // 회원 탈퇴 시 사용자가 생성한 모든 플랜 삭제
+    @Override
+    @Transactional
+    public void removeAllPlanByUser(User user) {
+        planRepository.deleteAllByPlanUser(user);
+    }
+
     @Override
     @Transactional
     public List<PlanListResponseDto> getPublicPlans() {
@@ -260,5 +267,12 @@ public class PlanServiceImpl implements PlanService {
             .likeNumber(likeService.countLikeByPlanId(summaryDto.getPlanId()))
             .planUserNickname(summaryDto.getPlanUserNickname())
             .build();
+    }
+
+    // 사용자가 생성한 플랜 조회
+    @Override
+    @Transactional(readOnly = true)
+    public List<Plan> getAllPlanByPlanUser(User user) {
+        return planRepository.findByPlanUser(user);
     }
 }

--- a/src/main/java/org/example/todotravel/domain/plan/service/implement/ScheduleServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/plan/service/implement/ScheduleServiceImpl.java
@@ -128,4 +128,11 @@ public class ScheduleServiceImpl implements ScheduleService {
         schedules.forEach(schedule -> scheduleList.add(ScheduleResponseDto.fromEntity(schedule)));
         return scheduleList;
     }
+
+    // 회원 탈퇴 시 사용자가 생성한 플랜의 모든 일정 삭제하기
+    @Override
+    @Transactional
+    public void deleteAllSchedulesByPlan(Plan plan) {
+        scheduleRepository.deleteAllByPlan(plan);
+    }
 }

--- a/src/main/java/org/example/todotravel/domain/user/repository/FollowRepository.java
+++ b/src/main/java/org/example/todotravel/domain/user/repository/FollowRepository.java
@@ -32,4 +32,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     @Query("SELECT DISTINCT f.followingUser FROM Follow f WHERE f.followerUser.userId = :userId")
     Page<User> findFollowingsByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    void deleteAllByFollowerUser(User user);
+    void deleteAllByFollowingUser(User user);
 }

--- a/src/main/java/org/example/todotravel/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/todotravel/domain/user/repository/UserRepository.java
@@ -23,4 +23,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 
     Optional<User> findUserIdByEmail(String email);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/org/example/todotravel/domain/user/service/FollowService.java
+++ b/src/main/java/org/example/todotravel/domain/user/service/FollowService.java
@@ -12,4 +12,5 @@ public interface FollowService {
     void stopFollowing(FollowRequestDto dto);
     PagedResponseDto<FollowResponseDto> getFollower(Long userId, int page, int size);
     PagedResponseDto<FollowResponseDto> getFollowing(Long userId, int page, int size);
+    void removeAllFollowRelationships(User user);
 }

--- a/src/main/java/org/example/todotravel/domain/user/service/UserService.java
+++ b/src/main/java/org/example/todotravel/domain/user/service/UserService.java
@@ -56,4 +56,6 @@ public interface UserService {
     void updateProfileImage(Long userId, MultipartFile file);
 
     User getProfileImageUrl(Long userId);
+
+    void removeUser(User user);
 }

--- a/src/main/java/org/example/todotravel/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/org/example/todotravel/domain/user/service/UserWithdrawalService.java
@@ -1,0 +1,8 @@
+package org.example.todotravel.domain.user.service;
+
+import org.example.todotravel.domain.user.entity.User;
+import reactor.core.publisher.Mono;
+
+public interface UserWithdrawalService {
+    void withdrawUser(User user);
+}

--- a/src/main/java/org/example/todotravel/domain/user/service/impl/FollowServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/user/service/impl/FollowServiceImpl.java
@@ -97,4 +97,12 @@ public class FollowServiceImpl implements FollowService {
 
         return new PagedResponseDto<>(followingDtos);
     }
+
+    // 회원 탈퇴 시 모든 팔로워, 팔로잉 삭제
+    @Override
+    @Transactional
+    public void removeAllFollowRelationships(User user) {
+        followRepository.deleteAllByFollowerUser(user);
+        followRepository.deleteAllByFollowingUser(user);
+    }
 }

--- a/src/main/java/org/example/todotravel/domain/user/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/user/service/impl/RefreshTokenServiceImpl.java
@@ -21,7 +21,7 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public Optional<RefreshToken> getRefreshTokenByUserId(Long userId) {
         return refreshTokenRepository.findByUser_UserId(userId);
     }

--- a/src/main/java/org/example/todotravel/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/user/service/impl/UserServiceImpl.java
@@ -269,4 +269,11 @@ public class UserServiceImpl implements UserService {
         return userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자입니다."));
 
     }
+
+    // 회원 탈퇴 시 사용자 정보 모두 삭제
+    @Override
+    @Transactional
+    public void removeUser(User user) {
+        userRepository.deleteByUserId(user.getUserId());
+    }
 }

--- a/src/main/java/org/example/todotravel/domain/user/service/impl/UserWithdrawalServiceImpl.java
+++ b/src/main/java/org/example/todotravel/domain/user/service/impl/UserWithdrawalServiceImpl.java
@@ -1,0 +1,166 @@
+package org.example.todotravel.domain.user.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.todotravel.domain.chat.entity.ChatRoom;
+import org.example.todotravel.domain.chat.service.ChatMessageService;
+import org.example.todotravel.domain.chat.service.ChatRoomService;
+import org.example.todotravel.domain.chat.service.ChatRoomUserService;
+import org.example.todotravel.domain.notification.service.AlarmService;
+import org.example.todotravel.domain.plan.entity.Plan;
+import org.example.todotravel.domain.plan.service.*;
+import org.example.todotravel.domain.user.entity.User;
+import org.example.todotravel.domain.user.service.FollowService;
+import org.example.todotravel.domain.user.service.RefreshTokenService;
+import org.example.todotravel.domain.user.service.UserService;
+import org.example.todotravel.domain.user.service.UserWithdrawalService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserWithdrawalServiceImpl implements UserWithdrawalService {
+
+    private final ChatRoomUserService chatRoomUserService;
+    private final RefreshTokenService refreshTokenService;
+    private final ChatMessageService chatMessageService;
+    private final BookmarkService bookmarkService;
+    private final PlanUserService planUserService;
+    private final ScheduleService scheduleService;
+    private final ChatRoomService chatRoomService;
+    private final CommentService commentService;
+    private final FollowService followService;
+    private final AlarmService alarmService;
+    private final LikeService likeService;
+    private final PlanService planService;
+    private final UserService userService;
+
+    @Override
+    @Transactional
+    public void withdrawUser(User user) {
+        try {
+            List<Plan> userPlans = planService.getAllPlanByPlanUser(user);
+
+            // 채팅 메시지 삭제를 비동기로 처리
+            CompletableFuture<Void> chatMessageDeletionFuture = CompletableFuture.runAsync(() ->
+                deleteChatMessages(userPlans).block()
+            );
+
+            // 나머지 작업은 동기적으로 수행
+            deleteUserData(user, userPlans);
+            handleNonCreatedPlans(user);
+
+            // 채팅 메시지 삭제 완료 대기
+            chatMessageDeletionFuture.join();
+
+            // 마지막으로 사용자 제거
+            userService.removeUser(user);
+
+        } catch (Exception e) {
+            log.error("회원 탈퇴 실패 (userId: {}): {}", user.getUserId(), e.getMessage());
+            // MySQL 데이터는 @Transactional 에 의해 자동 롤백
+            // 채팅 메시지 복구를 비동기로 처리
+            CompletableFuture.runAsync(() ->
+                restoreChatMessages(planService.getAllPlanByPlanUser(user)).block()
+            );
+            throw new RuntimeException("회원 탈퇴 실패", e);
+        }
+    }
+
+    // 생성한 플랜의 채팅방에 존재하는 메시지 모두 삭제
+    private Mono<Void> deleteChatMessages(List<Plan> userPlans) {
+        return Mono.fromCallable(() -> chatRoomService.getAllChatRoomByPlan(userPlans))
+            .flatMapIterable(rooms -> rooms)
+            .flatMap(chatRoom -> chatMessageService.deleteAllMessageForChatRoom(chatRoom.getRoomId()))
+            .then();
+    }
+
+    // 사용자 관련 데이터 삭제 수행
+    private void deleteUserData(User user, List<Plan> userPlans) {
+        Long userId = user.getUserId();
+
+        alarmService.deleteAllAlarm(userId);
+        refreshTokenService.deleteRefreshToken(userId);
+        followService.removeAllFollowRelationships(user);
+
+        // 사용자가 생성한 플랜의 채팅방 삭제
+        List<ChatRoom> chatRooms = chatRoomService.getAllChatRoomByPlan(userPlans);
+        for (ChatRoom chatRoom : chatRooms) {
+            chatRoomUserService.removeAllUserFromChatRoom(chatRoom);
+            chatRoomService.deleteChatRoom(chatRoom.getRoomId());
+        }
+
+        // 사용자가 생성한 플랜에 대해 모두 삭제
+        for (Plan plan : userPlans) {
+            deleteEntirePlan(plan);
+        }
+    }
+
+    // 사용자가 생성하지 않은 플랜에 대한 삭제
+    private void handleNonCreatedPlans(User user) {
+        commentService.removeAllCommentByUser(user);
+        likeService.removeAllLikeByUser(user);
+        bookmarkService.removeAllBookmarkByUser(user);
+
+        List<Plan> participatingPlans = planUserService.getAllPlansByUser(user);
+        for (Plan plan : participatingPlans) {
+            handleParticipatingPlan(user, plan);
+        }
+    }
+
+    // 참여하고 있는 플랜에 대한 처리
+    private void handleParticipatingPlan(User user, Plan plan) {
+        ChatRoom chatRoom = chatRoomService.getChatRoomByPlanId(plan.getPlanId());
+        if (chatRoom.getChatRoomUsers().size() == 1 || plan.getPlanUsers().size() == 1) {
+            deleteEntirePlan(plan);
+            chatRoomUserService.removeAllUserFromChatRoom(chatRoom);
+            chatRoomService.deleteChatRoom(chatRoom.getRoomId());
+        } else {
+            updateUserInPlan(user, plan, chatRoom);
+        }
+    }
+
+    // 참여하고 있는 플랜 중 나머지 인원이 존재할 때
+    private void updateUserInPlan(User user, Plan plan, ChatRoom chatRoom) {
+        String oldNickname = user.getNickname();
+        try {
+            chatMessageService.updateNicknameForUser(user.getUserId(), "(알 수 없음)")
+                .doOnSuccess(v -> {
+                    chatRoomUserService.removeUserFromChatRoom(chatRoom, user);
+                    planUserService.removePlanUserFromPlan(plan, user);
+                })
+                .doOnError(e -> {
+                    log.error("Error updating nickname for user ID: {}", user.getUserId(), e);
+                    chatMessageService.updateNicknameForUser(user.getUserId(), oldNickname).block();
+                })
+                .block();
+        } catch (Exception e) {
+            log.error("Error in updateUserInPlan for user ID: {}", user.getUserId(), e);
+            chatMessageService.restoreNicknameForUser(user.getUserId(), oldNickname).block();
+            throw new RuntimeException("Failed to update user in plan", e);
+        }
+    }
+
+    // 사용자가 생성한 플랜의 댓글, 좋아요, 북마크, 참여자, 일정, 해당 플랜 순서대로 삭제
+    private void deleteEntirePlan(Plan plan) {
+        commentService.removeAllCommentByPlan(plan);
+        likeService.removeAllLikeByPlan(plan);
+        bookmarkService.removeAllBookmarksByPlan(plan);
+        planUserService.removePlanUserFromOwnPlan(plan);
+        scheduleService.deleteAllSchedulesByPlan(plan);
+        planService.deletePlan(plan.getPlanId());
+    }
+
+    // 탈퇴 중 오류 발생 시 채팅 메시지 복구
+    private Mono<Void> restoreChatMessages(List<Plan> userPlans) {
+        return Mono.fromCallable(() -> chatRoomService.getAllChatRoomByPlan(userPlans))
+            .flatMapIterable(rooms -> rooms)
+            .flatMap(chatRoom -> chatMessageService.restoreMessagesForChatRoom(chatRoom.getRoomId()))
+            .then();
+    }
+}

--- a/src/main/java/org/example/todotravel/global/config/JpaConfig.java
+++ b/src/main/java/org/example/todotravel/global/config/JpaConfig.java
@@ -1,0 +1,18 @@
+package org.example.todotravel.global.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class JpaConfig {
+
+    @Bean(name = "transactionManager")
+    @Primary
+    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+        return new JpaTransactionManager(entityManagerFactory);
+    }
+}

--- a/src/main/java/org/example/todotravel/global/config/mongo/ChatMongoDBConfig.java
+++ b/src/main/java/org/example/todotravel/global/config/mongo/ChatMongoDBConfig.java
@@ -1,0 +1,29 @@
+package org.example.todotravel.global.config.mongo;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
+import org.springframework.data.mongodb.ReactiveMongoTransactionManager;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.transaction.reactive.TransactionalOperator;
+
+@Configuration
+@EnableMongoRepositories(basePackages = "org.example.todotravel.domain.chat.repository")
+public class ChatMongoDBConfig {
+    @Bean(name = "reactiveMongoTransactionManager")
+    public ReactiveMongoTransactionManager reactiveMongoTransactionManager(ReactiveMongoDatabaseFactory factory) {
+        return new ReactiveMongoTransactionManager(factory);
+    }
+
+    @Bean
+    public TransactionalOperator transactionalOperator(ReactiveMongoTransactionManager reactiveMongoTransactionManager) {
+        return TransactionalOperator.create(reactiveMongoTransactionManager);
+    }
+
+    @Bean
+    public ReactiveMongoTemplate reactiveMongoTemplate(ReactiveMongoDatabaseFactory factory, MappingMongoConverter converter) {
+        return new ReactiveMongoTemplate(factory, converter);
+    }
+}


### PR DESCRIPTION
## 변경 사항
Refactor: 마이페이지 - 댓글 조회에 대해서 플랜의 title, location 추가
Refactor: 한 채팅방에 사용자가 이미 존재할 경우에 대한 에러 추가
Feat: JPA 트랜잭션 매니저 설정 추가
Feat: MongoDB 리액티브 트랜잭션 설정 추가
Feat: 회원 탈퇴에 필요한 메서드 추가
Feat: 회원 탈퇴 시 채팅 메시지 관련 관리 기능 추가
Feat: 회원 탈퇴 전체 로직 처리

## To Reviewers
채팅 메시지 관련해서는 비동기로 보상 트랜잭션으로 작동하도록 구현했고, 나머지는 동기적으로 삭제되도록 처리했습니다..
최대한 구현하긴 했는데, 특정 부분에서 오류가 또 있을지 모르겠네요..... 일단 작동은 잘 되긴 합니다.


## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).